### PR TITLE
Support micro-images (scratch) by static linking

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -22,7 +22,7 @@ gzip -c dist/smokescreen-darwin-arm64 > dist/smokescreen-darwin-arm64.gz
 echo ""
 
 echo "Compiling for Intel Linux"
-GOOS=linux GOARCH=amd64 go build -o dist/smokescreen-linux-amd64
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o dist/smokescreen-linux-amd64
 chmod +x dist/smokescreen-linux-amd64
 echo "👍  dist/smokescreen-linux-amd64"
 gzip -c dist/smokescreen-linux-amd64 > dist/smokescreen-linux-amd64.gz


### PR DESCRIPTION
CGO_ENABLED=1 is the default and [enables the creation of go code that calls C code](https://golang.org/cmd/cgo/#hdr-Special_cases) – but the rub is that the binary produced is not statically linked. This causes issues we try to insert the built binary in a `scratch` or `alpine` docker microimage. The previous image we made on our own version of Smokescreen didn't need `CGO_ENABLED`, so I'm hoping this one doesn't either.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/30171259/111094060-7e8dbb00-858e-11eb-8c74-3d2415f99f3f.png">

It works fine if we use a fatter image like `buster`, but that's not ideal for final image size. For some reason, this doesn't seem to be a problem for the arm64 binary, maybe due to cross compilation doing some linking.